### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/uim-docs/site/assets/javascripts/extra.js
+++ b/uim-docs/site/assets/javascripts/extra.js
@@ -83,7 +83,10 @@ function initializeVersionSelector() {
     // Add event listener to version selector
     versionSelector.addEventListener('change', (event) => {
       const version = event.target.value;
-      window.location.href = `/${version}/`;
+      if (!/^[a-zA-Z0-9._-]+$/.test(version)) {
+        return;
+      }
+      window.location.href = `/${encodeURIComponent(version)}/`;
     });
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/synaptiai/uim-protocol/security/code-scanning/4](https://github.com/synaptiai/uim-protocol/security/code-scanning/4)

General fix: validate and constrain `event.target.value` before using it in any sensitive sink. Only allow expected version token characters (or, even better, an explicit allowlist), and reject/fallback on invalid input.

Best fix for this snippet: in `uim-docs/site/assets/javascripts/extra.js`, inside `initializeVersionSelector()` (around lines 84–87), sanitize `event.target.value` using a strict regex such as `^[a-zA-Z0-9._-]+$`. If invalid, return early. If valid, use `encodeURIComponent(version)` when building the path, then assign to `window.location.href`. This keeps existing behavior for normal version strings while preventing injection/path abuse patterns.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
