### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/synaptiai/uim-protocol/security/code-scanning/2](https://github.com/synaptiai/uim-protocol/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal token access.  
Best fix without changing functionality: set:

- `contents: read`

This is sufficient for checkout and typical read-only CI tasks shown here, and does not grant unnecessary write access.  
Change location: right after the `on:` triggers block (before `jobs:`), so both `lint` and `test` jobs inherit it automatically.

No imports, methods, or extra definitions are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
