### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/synaptiai/uim-protocol/security/code-scanning/1](https://github.com/synaptiai/uim-protocol/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml`, directly after the `on:` triggers (or before `jobs:`), so it applies to both `lint` and `test` jobs.  
The least-privilege baseline for this workflow is:

- `contents: read`

This preserves existing behavior (checkout and reads) while preventing unintended write scopes from defaults. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
