### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/uim-docs/docs/assets/javascripts/extra.js
+++ b/uim-docs/docs/assets/javascripts/extra.js
@@ -83,7 +83,13 @@ function initializeVersionSelector() {
     // Add event listener to version selector
     versionSelector.addEventListener('change', (event) => {
       const version = event.target.value;
-      window.location.href = `/${version}/`;
+      const safeVersionPattern = /^[A-Za-z0-9._-]+$/;
+
+      if (!safeVersionPattern.test(version)) {
+        return;
+      }
+
+      window.location.href = `/${encodeURIComponent(version)}/`;
     });
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/synaptiai/uim-protocol/security/code-scanning/3](https://github.com/synaptiai/uim-protocol/security/code-scanning/3)

Use strict validation (allowlist) on `event.target.value` before using it to build a navigation URL.

Best fix in this file:
- In `initializeVersionSelector`, validate `version` against a safe pattern (for example alphanumerics plus `.` `_` `-` only).
- If invalid, abort navigation.
- If valid, URL-encode the segment before interpolation to ensure safe path construction.

This preserves functionality (navigating to `/{version}/`) while preventing malicious or malformed values from being used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
